### PR TITLE
Improve type information

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Usage:
 ```python
 import logging
 
-from pyfun_events import Handle,Get
+from pyfun_events import Handle, Get
 
 counter = 0
 
@@ -21,13 +21,13 @@ counter = 0
 # @Handle assumes json body. For string or other body conversion, try:
 # @Handle(str)
 @Handle
-def DoEvent(data: str, context: dict):
+def DoEvent(data: object, context: dict):
     logging.info(data)
     counter = counter + 1
 
 
 @Handle(path="/secret")
-def DoOther(data: str, context: dict):
+def DoOther(data: object, context: dict):
     if data.get("handshake") == "backwards":
         counter = 0
         return "It's gone, man"
@@ -36,8 +36,8 @@ def DoOther(data: str, context: dict):
 @Get
 def Info():
     return "Got {0}".format(counter)
-    
-    
+
+
 @Get("/dance")
 def Party():
     return "<BLINK>Like it's 1999</BLINK>"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Usage:
 
 ```python
 import logging
+from typing import Any
 
 from pyfun_events import Handle, Get
 
@@ -21,13 +22,13 @@ counter = 0
 # @Handle assumes json body. For string or other body conversion, try:
 # @Handle(str)
 @Handle
-def DoEvent(data: object, context: dict):
+def DoEvent(data: Any, context: dict):
     logging.info(data)
     counter = counter + 1
 
 
 @Handle(path="/secret")
-def DoOther(data: object, context: dict):
+def DoOther(data: Any, context: dict):
     if data.get("handshake") == "backwards":
         counter = 0
         return "It's gone, man"

--- a/pyfun_events/__init__.py
+++ b/pyfun_events/__init__.py
@@ -1,3 +1,3 @@
 from .run import Handle,Get
 
-__all__ = ['handle', 'Get']
+__all__ = ['Handle', 'Get']

--- a/pyfun_events/run.py
+++ b/pyfun_events/run.py
@@ -1,45 +1,46 @@
 #!/usr/bin/python3
 #
-# A simple function to dump delivered events to stdout and report them
-# via web page.
-
-import logging
-from glob import glob
-import importlib
-from inspect import signature, isfunction
-import os.path
+# A simple function framework
 
 from cloudevents.sdk.event import v02
 from cloudevents.sdk import marshaller
 from flask import Flask, request
-from typing import Callable, TypeVar, Mapping
+from typing import Any, Callable, Optional, Union, overload, cast
 import ujson
-
-import pyfun_events.run
-
 
 app = Flask(__name__)
 
 
-def Handle(unpack: Callable[[str], object]=ujson.loads, path: str='/', **kwargs):
+Handler = Callable[[Any, dict], None]
+
+GetHandler = Callable[[], None]
+
+@overload
+def Handle(path: Handler) -> Handler:
+    ...
+
+@overload
+def Handle(
+      path: str="/",
+      unpack: Callable[[str], Any]=ujson.loads,
+      **kwargs) -> Callable[[Handler], Handler]:
+    ...
+
+def Handle(
+    path: Union[str, Handler]='/',
+    unpack: Callable[[str], Any]=ujson.loads,
+    **kwargs):
     """Decorate a function to handle events.
 
     Assumes func is a method which takes two arguments: data and context.
     data: provided the body of the event, processed via the unpack function.
     context: a dict containing cloudevents context attributes.
     """
-    # It would be nice to support both decorating a function as
-    # @Handle and @Handle(params). This is more difficult because
-    # unpack is also a function, and the no-parens version of the
-    # annotation will pass the function as the first
-    # argument. Fortunately, a event-handling function takes at least
-    # two arguments, so we can inspect the function to determine if we
-    # are in the no-arg case.
-    no_arg = False
-    if isfunction(unpack) and len(signature(unpack).parameters) >= 1:
-        no_arg = unpack
-        unpack = ujson.loads
-    def wrap(func: Callable[[object, dict], None]) -> None:
+    no_arg = None  # type: Optional[Handler]
+    if not isinstance(path, str):
+        no_arg = cast(Handler, path)
+        path = '/'
+    def wrap(func: Handler) -> Handler:
         def handle():
             m = marshaller.NewDefaultHTTPMarshaller()
             event = m.FromRequest(
@@ -48,23 +49,29 @@ def Handle(unpack: Callable[[str], object]=ujson.loads, path: str='/', **kwargs)
                 request.data,
                 unpack)
             return func(event.Data(), event)
-
-        pyfun_events.run.app.add_url_rule(path, func.__name__, handle, methods=['POST'], **kwargs)
+        app.add_url_rule(path, func.__name__, handle, methods=['POST'], **kwargs)
+        return func
     if no_arg:
         return wrap(no_arg)
     return wrap
 
+@overload
+def Get(path: GetHandler) -> GetHandler:
+    ...
 
-def Get(path: str='/', **kwargs):
+@overload
+def Get(path: str='/', **kwargs) -> Callable[[GetHandler], GetHandler]:
+    ...
+
+def Get(path: Union[str, GetHandler]='/', **kwargs):
     """Decorate a function to respond to Get requests.
     """
-    no_arg = False
-    if callable(path):
-        # Is actually a plain decorator
-        no_arg = path
+    no_arg = None  # type: Optional[GetHandler]
+    if not isinstance(path, str):
+        no_arg = cast(GetHandler, path)
         path = '/'
     def wrap(func: Callable[[], None]) -> None:
-        pyfun_events.run.app.add_url_rule(path, func.__name__, func, **kwargs)
+        app.add_url_rule(path, func.__name__, func, **kwargs)
     if no_arg:
         return wrap(no_arg)
     return wrap

--- a/pyfun_events/run.py
+++ b/pyfun_events/run.py
@@ -5,11 +5,12 @@
 from cloudevents.sdk.event import v02
 from cloudevents.sdk import marshaller
 from flask import Flask, request
-from typing import Any, Callable, Optional, Union, overload, cast
+from typing import Any, Callable, Optional, TypeVar, Union, overload, cast
 import ujson
 
 app = Flask(__name__)
 
+T = TypeVar('T')
 
 Handler = Callable[[Any, dict], None]
 
@@ -22,8 +23,8 @@ def Handle(path: Handler) -> Handler:
 @overload
 def Handle(
       path: str="/",
-      unpack: Callable[[str], Any]=ujson.loads,
-      **kwargs) -> Callable[[Handler], Handler]:
+      unpack: Callable[[str], T]=ujson.loads,
+      **kwargs) -> Callable[[Callable[[T, dict], None]], Callable[[T, dict], None]]:
     ...
 
 def Handle(


### PR DESCRIPTION
* Decorators now have overloaded type definitions, allowing checked use in either bare or with-argument form
* Use a type variable to capture the return type of unpack, and ensure that it's the input type of the handler.
* Fix example in readme to match updated types

Also makes the decorated functions still exist to the user (decorators now return the function), and changes order of path<->unpack arguments to make typing easier.